### PR TITLE
Fix Ollama proxy path

### DIFF
--- a/server.cjs
+++ b/server.cjs
@@ -13,7 +13,7 @@ app.use('/ollama-api', createProxyMiddleware({
   target: 'http://localhost:11434', // Default Ollama port
   changeOrigin: true,
   pathRewrite: {
-    '^/ollama-api': '', // remove /ollama-api prefix when forwarding
+    '^/ollama-api': '/api', // forward requests to the Ollama /api namespace
   },
   onProxyReq: (proxyReq, req, res) => {
     // Optional: Log proxy requests for debugging


### PR DESCRIPTION
## Summary
- fix proxy forwarding to Ollama by routing requests to `/api`

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ab547628ac832c91f1a5343d8b50e2