### PR TITLE
refactor: move prompt handling to client

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -59,7 +59,6 @@ function App() {
     models = [],
     isConnected,
     isLoading: modelsLoading,
-    error: ollamaError,
     checkConnection,
     generateResponse,
     pullModel,
@@ -74,7 +73,7 @@ function App() {
   console.log('App.tsx: models from useOllama:', models); // Added console.log
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const { toasts, showToast, dismissToast } = useToast(); // Initialize useToast
-  const { history: clipboardItems, copyToClipboard } = useClipboard(); // Initialize useClipboard // Initialize useToast
+  const { history: clipboardItems } = useClipboard(); // Initialize useClipboard
 
   const activeChatSession = chatSessions.find(session => session.id === activeChatSessionId);
   const messages = activeChatSession ? activeChatSession.messages : [];
@@ -500,7 +499,6 @@ function App() {
         onDeleteModel={deleteModel}
         isModelsLoading={modelsLoading}
         onModelSelect={(modelName: string) => updateSettings({ ollama: { ...settings.ollama, model: modelName } })}
-        promptId={settings.promptId}
         memoryService={memoryService} // Pass memoryService to SettingsModal
         deleteMemory={deleteMemory} // Pass deleteMemory to SettingsModal
         memories={memories} // Pass memories to SettingsModal

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -5,7 +5,7 @@ import { User, Bot, Copy, Check, ChevronDown, ChevronUp } from 'lucide-react';
 import { clsx } from 'clsx';
 import { AnimatedTextMessage } from './AnimatedTextMessage';
 import { useClipboard } from '../../hooks/useClipboard';
-import { parseMessageContent, MessageSegment } from '../../utils/markdownParser';
+import { parseMessageContent } from '../../utils/markdownParser';
 
 interface ChatMessageProps {
   message: Message;

--- a/src/components/settings/DirectorySelector.tsx
+++ b/src/components/settings/DirectorySelector.tsx
@@ -41,7 +41,7 @@ export function DirectorySelector({
       if (isValid) {
         onPathChange(path);
       }
-    } catch (error) {
+    } catch {
       setValidationResult('invalid');
     } finally {
       setIsValidating(false);

--- a/src/components/settings/ModelSelector.tsx
+++ b/src/components/settings/ModelSelector.tsx
@@ -1,8 +1,8 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useMemo } from 'react';
 import { Download, RefreshCw, Check, AlertCircle, Trash2 } from 'lucide-react';
 import { Button } from '../ui/Button';
 import { Input } from '../ui/Input';
-import { OllamaModel, OllamaAPI } from '../../services/ollamaApi';
+import { OllamaModel } from '../../services/ollamaApi';
 import { clsx } from 'clsx';
 import { useSettings } from '../../hooks/useSettings';
 

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -20,7 +20,6 @@ interface SettingsModalProps {
   isModelsLoading: boolean;
   onDeleteModel: (modelName: string) => Promise<void>;
   models: OllamaModel[]; // Added models prop
-  promptId: string; // New prop
   memoryService: MemoryService | null; // New prop for memory service
   deleteMemory: (id: string) => void; // New prop for deleting memory
   memories: Memory[]; // New prop for memories
@@ -37,7 +36,6 @@ export function SettingsModal({
   isModelsLoading,
   onDeleteModel,
   models,
-  promptId,
   memoryService,
   deleteMemory,
   memories,

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { CheckCircle, Info, XCircle } from 'lucide-react';
 import { clsx } from 'clsx';

--- a/src/hooks/useOllama.ts
+++ b/src/hooks/useOllama.ts
@@ -1,12 +1,12 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { OllamaAPI, OllamaModel } from '../services/ollamaApi';
 import { useSettings } from './useSettings';
-import { promptApi, Prompt } from '../services/promptApi';
+import { promptApi } from '../services/promptApi';
 import { MemoryService } from '../services/memoryService';
 import { useToast } from './useToast'; // Import useToast
 
 export function useOllama() {
-  const { settings } = useSettings();
+  const { settings, updateSettings } = useSettings();
   const [api, setApi] = useState<OllamaAPI | null>(null);
   const [models, setModels] = useState<OllamaModel[]>([]);
   const [isConnected, setIsConnected] = useState(false);
@@ -21,12 +21,12 @@ export function useOllama() {
 
   // Initialize API when settings change
   useEffect(() => {
-    const effectiveOllamaHost = settings.ollama.host === 'localhost' && window.location.hostname !== 'localhost'
-      ? window.location.hostname
-      : settings.ollama.host;
+    const isWildcardHost = settings.ollama.host === 'localhost' || settings.ollama.host === '0.0.0.0';
+    const effectiveOllamaHost = isWildcardHost ? window.location.hostname : settings.ollama.host;
 
     if (effectiveOllamaHost && settings.ollama.port) {
-      const newApi = new OllamaAPI(); // Uses default '/ollama-api'
+      const baseUrl = `http://${effectiveOllamaHost}:${settings.ollama.port}${settings.ollama.path || '/api'}`;
+      const newApi = new OllamaAPI(baseUrl);
       setApi(newApi);
     }
   }, [settings.ollama.host, settings.ollama.port, settings.ollama.path]);
@@ -302,7 +302,7 @@ export function useOllama() {
     }
   }, []);
 
-  const pullModel = useCallback(async (modelName: string, onProgress?: (progress: any) => void) => {
+  const pullModel = useCallback(async (modelName: string, onProgress?: (progress: unknown) => void) => {
     if (!api) {
       throw new Error('Ollama API not initialized');
     }

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -7,7 +7,7 @@ const defaultSettings: AppSettings = {
     port: 11434,
     path: '/api',
     model: '',
-    modelsDirectory: 'F:\AI\Ollama Models',
+    modelsDirectory: 'F:/AI/Ollama Models',
   },
   promptId: 'fallback',
   selectedModelComplexity: 'complex',
@@ -39,8 +39,8 @@ export function useSettings() {
       }
     }
 
-    // Automatic Ollama host configuration for external access
-    if (loadedSettings.ollama.host === 'localhost' && window.location.hostname !== 'localhost') {
+    // Automatic Ollama host configuration for external or wildcard hosts
+    if (loadedSettings.ollama.host === 'localhost' || loadedSettings.ollama.host === '0.0.0.0') {
       loadedSettings = {
         ...loadedSettings,
         ollama: {

--- a/src/services/ollamaApi.ts
+++ b/src/services/ollamaApi.ts
@@ -34,16 +34,16 @@ export interface OllamaResponse {
 export class OllamaAPI {
   private baseUrl: string;
 
-  // Constructor now takes an optional base URL for the proxy
-  constructor(proxyBaseUrl: string = '/ollama-api') {
-    this.baseUrl = proxyBaseUrl;
+  // Constructor takes the full base URL of the Ollama API
+  constructor(baseUrl: string = 'http://localhost:11434/api') {
+    this.baseUrl = baseUrl;
   }
 
   async isAvailable(): Promise<boolean> {
     try {
       const response = await fetch(`${this.baseUrl}/tags`);
       return response.ok;
-    } catch (error) {
+    } catch {
       return false;
     }
   }
@@ -55,6 +55,7 @@ export class OllamaAPI {
         throw new Error(`HTTP error! status: ${response.status}`);
       }
       const data = await response.json();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const modelsWithComplexity = (data.models || []).map((model: any) => ({
         ...model,
         complexity: model.name.toLowerCase().includes('mini') || model.name.toLowerCase().includes('tiny') ? 'simple' : 'complex',
@@ -158,7 +159,7 @@ export class OllamaAPI {
     }
   }
 
-  async pullModel(model: string, onProgress?: (progress: any) => void): Promise<void> {
+  async pullModel(model: string, onProgress?: (progress: unknown) => void): Promise<void> {
     try {
       const response = await fetch(`${this.baseUrl}/pull`, {
         method: 'POST',
@@ -189,8 +190,8 @@ export class OllamaAPI {
           for (const line of lines) {
             try {
               const data = JSON.parse(line);
-              onProgress(data);
-            } catch (e) {
+              onProgress?.(data);
+            } catch {
               // Skip invalid JSON lines
             }
           }

--- a/src/services/promptApi.ts
+++ b/src/services/promptApi.ts
@@ -1,5 +1,3 @@
-const API_BASE_URL = '/api/prompts';
-
 export interface Prompt {
   id: string;
   name: string;
@@ -7,85 +5,124 @@ export interface Prompt {
   isFallback: boolean;
 }
 
+interface PromptData {
+  activePromptId: string;
+  prompts: Record<string, Prompt>;
+}
+
+const STORAGE_KEY = 'prompt-data';
+
+const defaultData: PromptData = {
+  activePromptId: 'fallback',
+  prompts: {
+    fallback: {
+      id: 'fallback',
+      name: 'Fallback Safe Prompt',
+      content: 'You are a helpful AI assistant.',
+      isFallback: true,
+    },
+  },
+};
+
+function loadData(): PromptData {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      return JSON.parse(stored) as PromptData;
+    }
+  } catch (error) {
+    console.error('Failed to load prompts from localStorage:', error);
+  }
+  saveData(defaultData);
+  return defaultData;
+}
+
+function saveData(data: PromptData): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  } catch (error) {
+    console.error('Failed to save prompts to localStorage:', error);
+  }
+}
+
 export const promptApi = {
   getPrompts: async (): Promise<Prompt[]> => {
-    const response = await fetch(API_BASE_URL);
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
-    }
-    return response.json();
+    const data = loadData();
+    return Object.values(data.prompts);
   },
 
   getActivePrompt: async (): Promise<Prompt> => {
-    const response = await fetch(`${API_BASE_URL}/active`);
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
-    }
-    return response.json();
+    const data = loadData();
+    return data.prompts[data.activePromptId] || data.prompts['fallback'];
   },
 
   getPromptById: async (id: string): Promise<Prompt> => {
-    const response = await fetch(`${API_BASE_URL}/${id}`);
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
+    const data = loadData();
+    const prompt = data.prompts[id];
+    if (!prompt) {
+      throw new Error('Prompt not found.');
     }
-    return response.json();
+    return prompt;
   },
 
   createPrompt: async (name: string, content: string): Promise<Prompt> => {
-    const response = await fetch(API_BASE_URL, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ name, content }),
-    });
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
-    }
-    return response.json();
+    const data = loadData();
+    const newId = Date.now().toString();
+    data.prompts[newId] = { id: newId, name, content, isFallback: false };
+    saveData(data);
+    return data.prompts[newId];
   },
 
   updatePrompt: async (id: string, name: string, content: string): Promise<Prompt> => {
-    const response = await fetch(`${API_BASE_URL}/${id}`, {
-      method: 'PUT',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ name, content }),
-    });
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
+    const data = loadData();
+    const existing = data.prompts[id];
+    if (!existing) {
+      throw new Error('Prompt not found.');
     }
-    return response.json();
+    if (existing.isFallback) {
+      throw new Error('Fallback prompt cannot be edited.');
+    }
+    data.prompts[id] = {
+      ...existing,
+      name: name || existing.name,
+      content: content || existing.content,
+    };
+    saveData(data);
+    return data.prompts[id];
   },
 
   deletePrompt: async (id: string): Promise<void> => {
-    const response = await fetch(`${API_BASE_URL}/${id}`, {
-      method: 'DELETE',
-    });
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
+    const data = loadData();
+    const existing = data.prompts[id];
+    if (!existing) {
+      throw new Error('Prompt not found.');
     }
+    if (existing.isFallback) {
+      throw new Error('Fallback prompt cannot be deleted.');
+    }
+    if (data.activePromptId === id) {
+      data.activePromptId = 'fallback';
+    }
+    delete data.prompts[id];
+    saveData(data);
   },
 
   setActivePrompt: async (id: string): Promise<Prompt> => {
-    const response = await fetch(`${API_BASE_URL}/active/${id}`, {
-      method: 'PUT',
-    });
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
+    const data = loadData();
+    const prompt = data.prompts[id];
+    if (!prompt) {
+      throw new Error('Prompt not found.');
     }
-    return response.json();
+    data.activePromptId = id;
+    saveData(data);
+    return prompt;
   },
 
   resetToFallback: async (): Promise<Prompt> => {
-    const response = await fetch(`${API_BASE_URL}/reset-fallback`, {
-      method: 'POST',
-    });
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
-    }
-    return response.json();
+    const data = loadData();
+    data.activePromptId = 'fallback';
+    saveData(data);
+    return data.prompts['fallback'];
   },
 };
+

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,19 +9,10 @@ export default defineConfig({
     host: true,
     port: 3000, // Set the primary port to 3000
     proxy: {
-      '/ollama-api': {
-        target: 'http://localhost:3001', // Point to your server.cjs
-        changeOrigin: true,
-        // No path rewrite needed here, as server.cjs expects /ollama-api
-      },
       '/python-api': {
         target: 'http://localhost:5000',
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/python-api/, ''),
-      },
-      '/api': {
-        target: 'http://localhost:3001',
-        changeOrigin: true,
       },
     },
   },


### PR DESCRIPTION
## Summary
- store prompt data in browser localStorage instead of server API
- allow direct configuration of Ollama API base URL
- initialize Ollama API client with computed URL and drop server proxies
- normalize wildcard Ollama hosts and clean up lint issues

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b744478f68832c867dd56258d66eda